### PR TITLE
Preserve @version and @encoding outside of ?xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.2] - 2026-01-07
+
+### Fixed
+
+- Preserve @version and @encoding attributes outside the ?xml node
+
 ## [0.5.1] - 2024-04-25
 
 ### Fixed

--- a/lib/oxml/parser.rb
+++ b/lib/oxml/parser.rb
@@ -31,8 +31,10 @@ module OXML
       @last_attr = "#{name}:#{str}"
       return if @delete_namespace_attributes
 
-      return if name == :version
-      return if name == :encoding
+      # @version and @encoding are attributes of the leading ?xml node we ignore. Checking for the
+      # empty array detects the ?xml origin. Without the check they would become leading nodes
+      return if name == :version && @arr.empty?
+      return if name == :encoding && @arr.empty?
 
       start_element("@#{name}")
       text(str)

--- a/lib/oxml/version.rb
+++ b/lib/oxml/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OXML
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end


### PR DESCRIPTION
`@version` and `@encoding` were identified and removed by name. This adds a positional check: Only remove them if there is no element yet, which should limit this to the `?xml` situation. 

Fixes https://github.com/xkwd/oxml/issues/2